### PR TITLE
[WIP] Rpc examples

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,90 @@
+package sdk
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"github.com/ethereum/go-ethereum/whisper/whisperv6"
+)
+
+type Client struct {
+	cw         *clientWrapper
+	keyID      string
+	address    string
+	minimumPoW float64
+}
+
+func NewClient(rpcclient RPCClient) *Client {
+	cw := newClientWrapper(rpcclient)
+	return &Client{cw: cw}
+}
+
+func (c *Client) Signup(password string) (string, error) {
+	resp, err := c.cw.StatusSignup(password)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Address, nil
+}
+
+func (c *Client) Login(address, password string) (string, error) {
+	resp, err := c.cw.StatusLogin(address, password)
+	if err != nil {
+		return "", err
+	}
+
+	c.keyID = resp.AddressKeyID
+
+	return resp.AddressKeyID, nil
+}
+
+func (c *Client) PublicChatSymKey(chatName string) (string, error) {
+	return c.cw.ShhGenerateSymKeyFromPassword(chatName)
+}
+
+func (c *Client) PublicChatTopic(chatName string) whisperv6.TopicType {
+	h := sha3.NewKeccak256()
+	h.Write([]byte(chatName))
+	fullTopic := h.Sum(nil)
+
+	return whisperv6.BytesToTopic(fullTopic)
+}
+
+func (c *Client) MakePayload(text string) string {
+	timestamp := time.Now().Unix() * 1000
+	format := `["~#c4",["%s","text/plain","~:public-group-user-message",%d,%d]]`
+	payload := fmt.Sprintf(format, text, timestamp*100, timestamp)
+
+	return payload
+}
+
+func (c *Client) Post(symKeyID string, topic whisperv6.TopicType, text string) (string, error) {
+	payload := c.MakePayload(text)
+	msg := &whisperv6.NewMessage{
+		SymKeyID:  symKeyID,
+		Sig:       c.keyID,
+		TTL:       10,
+		Topic:     topic,
+		Payload:   []byte(payload),
+		PowTime:   1,
+		PowTarget: 0.001,
+	}
+
+	return c.cw.ShhPost(msg)
+}
+
+func (c *Client) NewFilter(topic whisperv6.TopicType, symKeyID string) (string, error) {
+	cr := whisperv6.Criteria{
+		AllowP2P: true,
+		Topics:   []whisperv6.TopicType{topic},
+		SymKeyID: symKeyID,
+	}
+
+	return c.cw.ShhNewMessageFilter(cr)
+}
+
+func (c *Client) FilterMessages(filterID string) ([]*whisperv6.Message, error) {
+	return c.cw.ShhFilterMessages(filterID)
+}

--- a/clientwrapper.go
+++ b/clientwrapper.go
@@ -1,0 +1,43 @@
+package sdk
+
+import (
+	"github.com/ethereum/go-ethereum/whisper/whisperv6"
+)
+
+type clientWrapper struct {
+	rpcClient RPCClient
+}
+
+func newClientWrapper(c RPCClient) *clientWrapper {
+	return &clientWrapper{c}
+}
+
+func (c *clientWrapper) StatusSignup(password string) (*SignupResponse, error) {
+	var resp SignupResponse
+	return &resp, c.rpcClient.Call(&resp, "status_signup", map[string]string{"password": password})
+}
+
+func (c *clientWrapper) StatusLogin(address, password string) (*LoginResponse, error) {
+	var resp LoginResponse
+	return &resp, c.rpcClient.Call(&resp, "status_login", map[string]string{"address": address, "password": password})
+}
+
+func (c *clientWrapper) ShhGenerateSymKeyFromPassword(password string) (string, error) {
+	var symKeyID string
+	return symKeyID, c.rpcClient.Call(&symKeyID, "shh_generateSymKeyFromPassword", password)
+}
+
+func (c *clientWrapper) ShhPost(msg *whisperv6.NewMessage) (string, error) {
+	var hash string
+	return hash, c.rpcClient.Call(&hash, "shh_post", msg)
+}
+
+func (c *clientWrapper) ShhNewMessageFilter(criteria whisperv6.Criteria) (string, error) {
+	var id string
+	return id, c.rpcClient.Call(&id, "shh_newMessageFilter", criteria)
+}
+
+func (c *clientWrapper) ShhFilterMessages(id string) ([]*whisperv6.Message, error) {
+	var msgs []*whisperv6.Message
+	return msgs, c.rpcClient.Call(&msgs, "shh_getFilterMessages", id)
+}

--- a/rpcclient.go
+++ b/rpcclient.go
@@ -1,17 +1,6 @@
 package sdk
 
-import "github.com/valyala/gorpc"
-
-// RPCClient is a client to manage all rpc calls
+//RPCClient is a client to manage all rpc calls
 type RPCClient interface {
-	Call(request interface{}) (response interface{}, err error)
-}
-
-func newRPC(address string) RPCClient {
-	rpc := &gorpc.Client{
-		Addr: address, // "rpc.server.addr:12345",
-	}
-	rpc.Start()
-
-	return rpc
+	Call(result interface{}, method string, args ...interface{}) error
 }

--- a/sdk.go
+++ b/sdk.go
@@ -3,12 +3,15 @@ package sdk
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
+
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // SDK is a set of tools to interact with status node
 type SDK struct {
-	RPCClient  RPCClient
+	rpcClient  RPCClient
 	address    string
 	pubkey     string
 	mnemonic   string
@@ -18,9 +21,9 @@ type SDK struct {
 }
 
 // New creates a default SDK object
-func New(address string) *SDK {
+func New(c *rpc.Client) *SDK {
 	return &SDK{
-		// RPCClient:  newRPC(address),
+		rpcClient:  c,
 		minimumPoW: 0.001,
 	}
 }
@@ -111,7 +114,6 @@ func (c *SDK) JoinPublicChannel(channelName string) (*Channel, error) {
 		channelKey: key,
 	}
 	c.channels = append(c.channels, ch)
-
 	return ch, nil
 }
 
@@ -128,8 +130,10 @@ func (c *SDK) calculatePublicChannelTopicID(name string, symkey int) (topicID st
 
 func (c *SDK) call(cmd string, res interface{}) error {
 	log.Println("[ REQUEST ] : " + cmd)
-	body, err := c.RPCClient.Call(cmd)
+	var body interface{}
+	err := c.rpcClient.Call(&res, cmd)
 	if err != nil {
+		fmt.Printf("%+v\n", err)
 		return err
 	}
 	log.Println("[ RESPONSE ] : " + body.(string))

--- a/types.go
+++ b/types.go
@@ -1,0 +1,11 @@
+package sdk
+
+type SignupResponse struct {
+	Address  string `json:"address"`
+	PubKey   string `json:"pubkey"`
+	Mnemonic string `json:"mnemonic"`
+}
+
+type LoginResponse struct {
+	AddressKeyID string `json:"address_key_id"`
+}


### PR DESCRIPTION
This is a WIP PR.

I started fixing the pinger/ponger example using RPC calls and it works via HTTP and IPC.

To test it, you need to enable the `Status` service in `statusd`, I created this PR to do it: https://github.com/status-im/status-go/pull/902

You can test it running `statusd` in background:

`make statusgo && ./build/bin/statusd  -shh=true -standalone=false -http=true -status`

I started separating the RPC from the public SDK calls so that they can tested separately.

the `Client` struct is what the `SDK` struct is now, but I created a new one just to have a clean PR before I port everything. 

What we can have now is:

* `Client`: it has an embedded struct `RemoteClient` that manages the remote calls. In the future we can have a `StatusClient` interface so that we can switch from `RemoteClient` to `EmbeddedClient` and use the client to call an external `statusd` node or embedding and running the node. 

* `RemoteClient` it manages RPC calls and return response structs, so that Client can return to the user simple values instead of the full responses.

* `rpcClient`: internally the `RemoteClient` uses the `go-ethereum/rpc.Client` that already manages errors based on status codes, and can be used with `context.Context`

For now pinger/ponger examples don't use the `Channel` structs and subscription yet but I'm going to update the code to use them.