### PR TITLE
Expose Channel and channel.PubKey as part of the message

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -177,6 +177,11 @@ func (c *Channel) removeSubscription(sub *Subscription) {
 	c.subscriptions = subs
 }
 
+// PubKey return the channel's associated publike key
+func (c *Channel) PubKey() string {
+	return c.account.PubKey
+}
+
 func (c *Channel) pollMessages() (msg *Msg) {
 	res, err := shhGetFilterMessagesRequest(c.account.conn, []string{c.filterID})
 	if err != nil {
@@ -189,6 +194,7 @@ func (c *Channel) pollMessages() (msg *Msg) {
 		for _, u := range vv {
 			msg, err = messageFromEnvelope(u)
 			if err == nil && supportedMessage(msg.Type) {
+				msg.Channel = c
 				msg.ChannelName = c.name
 				return
 			}

--- a/msg.go
+++ b/msg.go
@@ -52,10 +52,11 @@ func supportedMessage(msgType string) bool {
 
 // Msg is a structure used by Subscribers and Publish().
 type Msg struct {
-	From        string `json:"from"`
-	ChannelName string `json:"channel"`
-	Raw         string `json:"-"`
-	Type        string `json:"-"`
+	From        string   `json:"from"`
+	ChannelName string   `json:"channel"`
+	Channel     *Channel `json:"-"`
+	Raw         string   `json:"-"`
+	Type        string   `json:"-"`
 	Properties  interface{}
 }
 


### PR DESCRIPTION
Expose the channel associated account public key through the channel's received message.