### PR TITLE
Normalize RPCClient Call method

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ func main() {
   // Here we create a new remote client against our running statusd
 	rpcClient, err := rpc.Dial("http://localhost:8545")
 	checkErr(err)
-	remoteClient := &remoteClient{rpcClient}
 
   // Setting up a new sdk client
-	client := sdk.New(remoteClient)
+	client := sdk.New(rpcClient)
 
   // We signup and login as a new account
 	a, err := client.SignupAndLogin("password")
@@ -119,15 +118,6 @@ func main() {
 		message := fmt.Sprintf("PING : %d", time.Now().Unix())
 		_ = ch.Publish(message)
 	}
-}
-
-// This is the remote client we will use to
-type remoteClient struct {
-	c *rpc.Client
-}
-
-func (rc *remoteClient) Call(req *sdk.Request, res interface{}) error {
-	return rc.c.Call(res, req.Method, req.Params)
 }
 
 func checkErr(err error) {

--- a/dictionary.go
+++ b/dictionary.go
@@ -15,7 +15,7 @@ type generateSymKeyFromPasswordResponse struct {
 func shhGenerateSymKeyFromPasswordRequest(sdk *SDK, password string) (string, error) {
 	// `{"jsonrpc":"2.0","id":2950,"method":"shh_generateSymKeyFromPassword","params":["%s"]}`
 	var resp string
-	return resp, sdk.call("shh_generateSymKeyFromPassword", password, &resp)
+	return resp, sdk.RPCClient.Call(&resp, "shh_generateSymKeyFromPassword", password)
 }
 
 type shhFilterFormatParam struct {
@@ -39,7 +39,7 @@ func newShhMessageFilterFormatRequest(sdk *SDK, topics []string, symKey string) 
 		SymKeyID: symKey,
 	}
 
-	return res, sdk.call("shh_newMessageFilter", params, &res)
+	return res, sdk.RPCClient.Call(&res, "shh_newMessageFilter", params)
 }
 
 type web3ShaResponse struct {
@@ -49,7 +49,7 @@ type web3ShaResponse struct {
 func web3Sha3Request(sdk *SDK, data string) (string, error) {
 	// `{"jsonrpc":"2.0","method":"web3_sha3","params":["%s"],"id":%d}`
 	var res string
-	return res, sdk.call("web3_sha3", data, &res)
+	return res, sdk.RPCClient.Call(&res, "web3_sha3", data)
 }
 
 type statusLoginParam struct {
@@ -70,7 +70,7 @@ func statusLoginRequest(sdk *SDK, address, password string) (*loginResponse, err
 		Password: password,
 	}
 
-	return &res, sdk.call("status_login", params, &res)
+	return &res, sdk.RPCClient.Call(&res, "status_login", params)
 }
 
 type statusSignupParam struct {
@@ -91,7 +91,7 @@ func statusSignupRequest(sdk *SDK, password string) (*signupResponse, error) {
 		Password: password,
 	}
 
-	return &res, sdk.call("status_signup", params, &res)
+	return &res, sdk.RPCClient.Call(&res, "status_signup", params)
 }
 
 type getFilterMessagesResponse struct {
@@ -102,7 +102,7 @@ func shhGetFilterMessagesRequest(sdk *SDK, filter string) (interface{}, error) {
 	// `{"jsonrpc":"2.0","id":2968,"method":"shh_getFilterMessages","params":["%s"]}`
 	var res interface{}
 
-	return res, sdk.call("shh_getFilterMessages", filter, &res)
+	return res, sdk.RPCClient.Call(&res, "shh_getFilterMessages", filter)
 }
 
 type Message struct {
@@ -127,5 +127,5 @@ type shhPostResponse struct {
 
 func shhPostRequest(sdk *SDK, msg *Message) (string, error) {
 	var res string
-	return res, sdk.call("shh_post", msg, &res)
+	return res, sdk.RPCClient.Call(&res, "shh_post", msg)
 }

--- a/examples/mitsuku/main.go
+++ b/examples/mitsuku/main.go
@@ -15,14 +15,6 @@ import (
 	sdk "github.com/status-im/status-go-sdk"
 )
 
-type remoteClient struct {
-	c *rpc.Client
-}
-
-func (rc *remoteClient) Call(req *sdk.Request, res interface{}) error {
-	return rc.c.Call(res, req.Method, req.Params)
-}
-
 func checkErr(err error) {
 	if err != nil {
 		log.Fatal(err)
@@ -35,8 +27,7 @@ func main() {
 	rpcClient, err := rpc.Dial("http://localhost:8545")
 	checkErr(err)
 
-	remoteClient := &remoteClient{rpcClient}
-	client := sdk.New(remoteClient)
+	client := sdk.New(rpcClient)
 
 	a, err := client.SignupAndLogin(pwd)
 

--- a/examples/pinger/main.go
+++ b/examples/pinger/main.go
@@ -13,8 +13,7 @@ func main() {
 	rpcClient, err := rpc.Dial("http://localhost:8545")
 	checkErr(err)
 
-	remoteClient := &remoteClient{rpcClient}
-	client := sdk.New(remoteClient)
+	client := sdk.New(rpcClient)
 
 	a, err := client.SignupAndLogin("password")
 	checkErr(err)
@@ -30,14 +29,6 @@ func main() {
 		message := fmt.Sprintf("PING : %d", time.Now().Unix())
 		_ = ch.Publish(message)
 	}
-}
-
-type remoteClient struct {
-	c *rpc.Client
-}
-
-func (rc *remoteClient) Call(req *sdk.Request, res interface{}) error {
-	return rc.c.Call(res, req.Method, req.Params)
 }
 
 func checkErr(err error) {

--- a/examples/ponger/main.go
+++ b/examples/ponger/main.go
@@ -11,14 +11,6 @@ import (
 	"github.com/status-im/status-go-sdk"
 )
 
-type remoteClient struct {
-	c *rpc.Client
-}
-
-func (rc *remoteClient) Call(req *sdk.Request, res interface{}) error {
-	return rc.c.Call(res, req.Method, req.Params)
-}
-
 func checkErr(err error) {
 	if err != nil {
 		log.Fatal(err)
@@ -29,8 +21,7 @@ func main() {
 	rpcClient, err := rpc.Dial("http://localhost:8545")
 	checkErr(err)
 
-	remoteClient := &remoteClient{rpcClient}
-	client := sdk.New(remoteClient)
+	client := sdk.New(rpcClient)
 
 	a, err := client.SignupAndLogin("password")
 	checkErr(err)

--- a/sdk.go
+++ b/sdk.go
@@ -1,12 +1,8 @@
 package sdk
 
-import (
-	"log"
-)
-
 // RPCClient is a client to manage all rpc calls
 type RPCClient interface {
-	Call(req *Request, res interface{}) error
+	Call(result interface{}, method string, args ...interface{}) error
 }
 
 // SDK is a set of tools to interact with status node
@@ -70,14 +66,4 @@ type Request struct {
 // NewMessageFilterResponse NewMessageFilter json response
 type NewMessageFilterResponse struct {
 	Result string `json:"result"`
-}
-
-func (c *SDK) call(method string, params interface{}, result interface{}) error {
-	log.Println("[ REQUEST ] : " + method)
-	req := &Request{
-		Method: method,
-		Params: params,
-	}
-
-	return c.RPCClient.Call(req, result)
 }


### PR DESCRIPTION
RPCClient interface now has the same structure as go-ethereum/rpc, so we can directly use rpc.Client as parameter to SDK constructor.

Given this, we can remove the remoteClient struct and the sdk.call method which standardizes the 'client.Call' interface to simply using sdk.RPCClient.Call every time.

Note that the removal of the sdk.call method removes the message logging. If this is important and there isn't another way to do it within RPCClient, we can add the sdk.Call method again, but this time using the new signature (`Call(result interface{}, method string, args ...interface{}) error
`) identical to that of RPCClient.Call.