### PR TITLE
Add tests to circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,9 @@ jobs:
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
     ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    working_directory: /go/src/github.com/status-im/status-go-sdk
     steps:
       - checkout
-      - run: make lint-install
+      - run: make setup
       - run: make lint
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+setup:
+	make lint-install
+	make dev-deps
+	make mock
+
 lint-install:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
@@ -15,6 +20,7 @@ dev-deps:
 	go get -u github.com/stretchr/testify
 	go get -u github.com/golang/mock/gomock
 	go get -u github.com/golang/mock/mockgen
+	go get -u github.com/ethereum/go-ethereum
 
 mock:
 	mockgen -package=sdk  -destination=sdk_mock.go -source=sdk.go


### PR DESCRIPTION
Addresses #19

CI will still fail because lint warnings still exists. Added a new issue (#27) to address lint errors separately. I  tested putting `make test` ahead of `make lint` and verified that `make test` is passing. 

This PR should be ready to merge