### PR TITLE
Fix login overridden address

### DIFF
--- a/account.go
+++ b/account.go
@@ -6,12 +6,13 @@ import (
 
 // Account represents a logged in user on statusd node
 type Account struct {
-	conn     *SDK
-	Address  string
-	PubKey   string
-	Mnemonic string
-	Username string
-	channels []*Channel
+	conn         *SDK
+	Address      string
+	AddressKeyID string
+	PubKey       string
+	Mnemonic     string
+	Username     string
+	channels     []*Channel
 }
 
 // JoinPublicChannel joins a status public channel

--- a/chan.go
+++ b/chan.go
@@ -117,7 +117,7 @@ func (c *Channel) ContactUpdateRequest(username, image string) error {
 // SendPostRawMsg sends a shh_post message with the given body.
 func (c *Channel) SendPostRawMsg(body string) error {
 	msg := Message{
-		Signature: c.account.Address,
+		Signature: c.account.AddressKeyID,
 		SymKeyID:  c.ChannelKey,
 		Payload:   rawrChatMessage(body),
 		Topic:     c.TopicID,

--- a/sdk.go
+++ b/sdk.go
@@ -26,14 +26,15 @@ func (c *SDK) Login(addr, pwd string) (a *Account, err error) {
 		return a, err
 	}
 	return &Account{
-		conn:    c,
-		Address: res.AddressKeyID,
+		conn:         c,
+		AddressKeyID: res.AddressKeyID,
 	}, err
 }
 
 // Signup creates a new account with the given credentials
 func (c *SDK) Signup(pwd string) (a *Account, err error) {
 	res, err := statusSignupRequest(c, pwd)
+
 	if err != nil {
 		return a, err
 	}
@@ -53,7 +54,7 @@ func (c *SDK) SignupAndLogin(password string) (a *Account, err error) {
 		return
 	}
 	la, err := c.Login(a.Address, password)
-	a.Address = la.Address
+	a.AddressKeyID = la.AddressKeyID
 	return
 }
 


### PR DESCRIPTION
The `address_key_id` returned by `status_login` endpoint is not the `address_key` returned by `status_signup` so it should not override this specific field.

Closes #22
